### PR TITLE
Parse the easybank transaction text

### DIFF
--- a/EasyBank.lua
+++ b/EasyBank.lua
@@ -55,9 +55,9 @@ function ListAccounts (knownAccounts)
         end
 
         -- Add Credit Card Accounts
-        local giroTable = mainPage:xpath("//*[@id='PART_CREDIT_CARD']")
-        local giroAccounts = AccountsFromTable(giroTable, AccountTypeCreditCard)
-        for i,acc in ipairs(giroAccounts) do
+        local creditCardTable = mainPage:xpath("//*[@id='PART_CREDIT_CARD']")
+        local creditCardAccounts = AccountsFromTable(creditCardTable, AccountTypeCreditCard)
+        for i,acc in ipairs(creditCardAccounts) do
                 table.insert(accounts, acc)
         end
 

--- a/EasyBank.lua
+++ b/EasyBank.lua
@@ -208,8 +208,12 @@ function TransactionFromTableRow (tableRow)
             end
         end
 
-        if lineIndex > lineIndexAccountName then
-            accountName = accountName .. ' ' .. table.concat(lines, ' ', lineIndexAccountName + 1)
+        if lineIndexAccountName == not nil then
+            if lineIndex > lineIndexAccountName then
+                accountName = accountName .. ' ' .. table.concat(lines, ' ', lineIndexAccountName + 1)
+            end
+        else
+            purpose = text
         end
 
         local transaction = {

--- a/EasyBank.lua
+++ b/EasyBank.lua
@@ -192,6 +192,13 @@ function TransactionFromTableRow (tableRow)
             lineIndex = lineIndex + 1
 
             for part in line:gmatch("%S+") do 
+
+                accountName = nil
+                accountNumber = nil
+                purpose = nil
+                bankCode = nil
+                lineIndexAccountName = nil
+
                 if isIban(part) then
                     accountNumber = part
                     purpose = table.concat(lines, "\r\n", 1, lineIndex - 1)

--- a/EasyBank.lua
+++ b/EasyBank.lua
@@ -55,9 +55,9 @@ function ListAccounts (knownAccounts)
         end
 
         -- Add Credit Card Accounts
-        local creditCardTable = mainPage:xpath("//*[@id='PART_CREDIT_CARD']")
-        local creditCardAccounts = AccountsFromTable(creditCardTable, AccountTypeCreditCard)
-        for i,acc in ipairs(creditCardAccounts) do
+        local giroTable = mainPage:xpath("//*[@id='PART_CREDIT_CARD']")
+        local giroAccounts = AccountsFromTable(giroTable, AccountTypeCreditCard)
+        for i,acc in ipairs(giroAccounts) do
                 table.insert(accounts, acc)
         end
 

--- a/EasyBank.lua
+++ b/EasyBank.lua
@@ -183,9 +183,42 @@ end
 
 
 function TransactionFromTableRow (tableRow)
+        local text = tableRow:xpath("td[4]"):text()
+        local lines = {}
+        local lineIndex = 0
+
+        for line in text:gmatch("[^\r\n]+") do
+            table.insert(lines, line)
+            lineIndex = lineIndex + 1
+
+            for part in line:gmatch("%S+") do 
+                if isIban(part) then
+                    accountNumber = part
+                    purpose = table.concat(lines, "\r\n", 1, lineIndex - 1)
+
+                    ibanPosStart = string.find(line, accountNumber)
+                    ibanPosEnd = ibanPosStart + string.len(accountNumber)
+
+                    accountName = string.sub(line, ibanPosEnd + 1)
+                    if ibanPosStart > 1 then
+                        bankCode = string.sub(line,0, ibanPosStart - 1)
+                    end
+                    lineIndexAccountName = lineIndex
+                end
+            end
+        end
+
+        if lineIndex > lineIndexAccountName then
+            accountName = accountName .. ' ' .. table.concat(lines, ' ', lineIndexAccountName + 1)
+        end
+
         local transaction = {
+--              bankCode = bankCode,
+                accountNumber = accountNumber,
+                name = accountName,
+                bankCode = bankCode,
                 bookingDate = DateStringToTimestamp(tableRow:xpath("td[2]"):text()),
-                purpose = tableRow:xpath("td[4]"):text(),
+                purpose = purpose,
                 amount = AmountStringToNumber(tableRow:xpath("td[10]"):text()),
                 valueDate = DateStringToTimestamp(tableRow:xpath("td[6]"):text())
         }
@@ -193,6 +226,30 @@ function TransactionFromTableRow (tableRow)
         return transaction
 end
 
+local length=
+{
+  AL=28, AD=24, AT=20, AZ=28, BH=22, BE=16, BA=20, BR=29, BG=22, CR=21,
+  HR=21, CY=28, CZ=24, DK=18, DO=28, EE=20, FO=18, FI=18, FR=27, GE=22,
+  DE=22, GI=23, GR=27, GL=18, GT=28, HU=28, IS=26, IE=22, IL=23, IT=27,
+  JO=30, KZ=20, KW=30, LV=21, LB=28, LI=21, LT=20, LU=20, MK=19, MT=31,
+  MR=27, MU=30, MC=27, MD=24, ME=22, NL=18, NO=15, PK=24, PS=29, PL=28,
+  PT=25, QA=29, RO=24, SM=27, SA=24, RS=22, SK=24, SI=19, ES=24, SE=24,
+  CH=21, TN=24, TR=26, AE=23, GB=22, VG=24
+}
+ 
+function isIban(iban)
+  iban=iban:gsub("%s","")
+  local l=length[iban:sub(1,2)]
+  if not l or l~=#iban or iban:match("[^%d%u]") then
+    return false -- invalid character, country code or length
+  end
+  local mod=0
+  local rotated=iban:sub(5)..iban:sub(1,4)
+  for c in rotated:gmatch(".") do
+    mod=(mod..tonumber(c,36)) % 97
+  end
+  return mod==1
+end
 
 function DateStringToTimestamp(dateString)
     local dayStr, monthStr, yearStr = string.match(dateString, "(%d%d).(%d%d).(%d%d%d%d)")


### PR DESCRIPTION
This patch tries to parse the transaction description currently delivered by easybank in HTML.

#### Detected fields

- accountNumber
- name
- bankCode
- purpose

#### Assumptions

- All lines before the occurrence of an account number (IBAN) contain purpose text.
- In the same line where an account number was found, anything before that account number is a (optional) bank code
- Anything else after the account number is the account name (in the same line and all following lines)

#### Pros
- Detailed assignment of transaction information
- Much more readable  and usable account information

#### Cons
Since the purpose text now only contains anything before the first occurence of an account number  there is a risk of data loss if my assumptions are wrong (I  hope not ;-)) or  easybank changes their html output.

Suggestions/improvements are welcome of course since this is my first code with lua and for moneymoney

Credits to https://rosettacode.org/wiki/IBAN#Lua for the IBAN validation!